### PR TITLE
Fixed fuel and added fuel warning

### DIFF
--- a/src/game/Game.tscn
+++ b/src/game/Game.tscn
@@ -7,7 +7,5 @@
 script = ExtResource( 1 )
 
 [node name="PlayerStats" parent="." instance=ExtResource( 2 )]
-margin_left = 0.0
 margin_top = 1.0
-margin_right = 0.0
 margin_bottom = 1.0

--- a/src/game/game-stats/WarningLabelContainer.gd
+++ b/src/game/game-stats/WarningLabelContainer.gd
@@ -1,14 +1,49 @@
 extends VBoxContainer
 
+var time = 0
+
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	$Warning.text = ""
 
 
 func _process(delta):
-	if GameStats.fuel == 0:
-		$Warning.text = "Out Of Fuel"
-	elif GameStats.fuel / 100 <= 20:
-		$Warning.text = "Low Fuel"
+	var visible = timer(delta)
+	if (visible):
+		if GameStats.fuel / 100 == 0:
+			$Warning.text = "Out Of Fuel"
+		elif GameStats.fuel / 100 <= 20:
+			$Warning.text = "Low Fuel"
+		else: 
+			$Warning.text = ""
 	else:
 		$Warning.text = ""
+		
+func timer(InDelta):
+	time += 1
+	if(GameStats.fuel / 100 > 10):
+		if(time < 40):
+			return true
+		elif(time < 80): 
+			return false
+		else:
+			time = 0
+			return false
+	elif(GameStats.fuel / 100 > 5):
+		if(time < 30):
+			return true
+		elif(time < 60): 
+			return false
+		else:
+			time = 0
+			return false
+	elif(GameStats.fuel / 100 > 0):
+		if(time < 15):
+			return true
+		elif(time < 30): 
+			return false
+		else:
+			time = 0
+			return false
+	else:
+		 return true

--- a/src/game/player/player.gd
+++ b/src/game/player/player.gd
@@ -15,11 +15,13 @@ func get_input():
 		rotation_dir += .5
 	if Input.is_key_pressed(65):
 		rotation_dir -= .5
-	if GameStats.fuel > 0:
+	if GameStats.fuel / 100 > 0:
 		if Input.is_key_pressed(87):
 			velocity.y -= 1
 			velocity = Vector2(speed,0).rotated(rotation)
-			GameStats.fuel = GameStats.fuel - 1
+			if (get_tree().current_scene.name != "TitleScreen"):
+				GameStats.fuel = GameStats.fuel - 1
+			
 		#Code for backwards movement if needed later	
 		#if Input.is_key_pressed(83):
 		#	velocity.y += 1
@@ -40,4 +42,5 @@ func _physics_process(delta):
 	#GameStats.position = get_node("/root/Game/System/Player").get_position()
 	get_input()
 	rotation += rotation_dir * rotation_speed * delta
+# warning-ignore:return_value_discarded
 	move_and_collide(velocity * delta)


### PR DESCRIPTION
Fixed a bug where moving on the title screen would drain the players fuel. 
Fuel warning now blinks faster according to how low the player's fuel is. 